### PR TITLE
More aggregators; install correctly.

### DIFF
--- a/partials/query.editor.html
+++ b/partials/query.editor.html
@@ -221,7 +221,7 @@
 			<select class="input-medium tight-form-input"
 				ng-change="ctrl.changeHorAggregationInput()"
 				ng-model="ctrl.target.currentHorizontalAggregatorName"
-				ng-options="f for f in ['avg','dev','max','min','rate','sampler','count','sum','least_squares','percentile','scale','div']"></select>
+				ng-options="f for f in ['avg','dev','max','min','rate','sampler','count','sum','least_squares','percentile','scale','div', 'first', 'gaps', 'last', 'diff']"></select>
 		</li>
 
 		<!-- Different parameters -->

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "kairosdb-datasource",
+  "id": "kairosdb",
   "name": "KairosDB",
   "type": "datasource",
 

--- a/query_ctrl.js
+++ b/query_ctrl.js
@@ -241,6 +241,7 @@ function (angular, _, sdk) {
         if (this.panel.hasSamplingRate) {aggregator.sampling_rate = this.target.horAggregator.samplingRate;}
         if (this.panel.hasUnit) {aggregator.unit = this.target.horAggregator.unit;}
         if (this.panel.hasFactor) {aggregator.factor = this.target.horAggregator.factor;}
+        if (this.panel.hasNothing) {aggregator.nothing = this.target.horAggregator.nothing;}
         if (this.panel.hasPercentile) {aggregator.percentile = this.target.horAggregator.percentile;}
         this.target.horizontalAggregators.push(aggregator);
         this.targetBlur();
@@ -250,6 +251,7 @@ function (angular, _, sdk) {
       this.panel.hasSamplingRate = false;
       this.panel.hasUnit = false;
       this.panel.hasFactor = false;
+      this.panel.hasNothing = false;
       this.panel.hasPercentile = false;
     };
 
@@ -263,10 +265,11 @@ function (angular, _, sdk) {
     };
 
     KairosDBQueryCtrl.prototype.changeHorAggregationInput = function() {
-      this.panel.hasSamplingRate = _.contains(['avg','dev','max','min','sum','least_squares','count','percentile'],
+      this.panel.hasSamplingRate = _.contains(['avg','dev','max','min','sum','least_squares','count','percentile', 'first', 'gaps', 'last'],
                                           this.target.currentHorizontalAggregatorName);
       this.panel.hasUnit = _.contains(['sampler','rate'], this.target.currentHorizontalAggregatorName);
       this.panel.hasFactor = _.contains(['div','scale'], this.target.currentHorizontalAggregatorName);
+      this.panel.hasNothing = _.contains(['diff'], this.target.currentHorizontalAggregatorName);
       this.panel.hasPercentile = 'percentile' === this.target.currentHorizontalAggregatorName;
       this.validateHorizontalAggregator();
     };


### PR DESCRIPTION
This PR adds the diff, first, last, gaps aggregators which are now supported in KairosDB.

It also appears to fix the issue I opened yesterday (https://github.com/grafana/kairosdb-datasource/issues/4)

The last bit is a little involved:
- rename the plugin to "kairosdb" in the config file
- install the plugin as `/var/lib/grafana/plugins/kairosdb` rather than as `/var/lib/grafana/plugins/kairosdb-datasource`
- restart the server
- delete the old datasource and make a new one (with your specific creds)

My suspicion is that my solution to installation is the Wrong Way, but I'm including it here for your consideration. Thanks for reading :)