### PR TITLE
update the templateurl to match the registered route grafana has for …

### DIFF
--- a/query_ctrl.js
+++ b/query_ctrl.js
@@ -27,7 +27,7 @@ function (angular, _, sdk) {
     KairosDBQueryCtrl.prototype = Object.create(_super.prototype);
     KairosDBQueryCtrl.prototype.constructor = KairosDBQueryCtrl;
 
-    KairosDBQueryCtrl.templateUrl = 'public/plugins/kairosdb/partials/query.editor.html';
+    KairosDBQueryCtrl.templateUrl = 'public/plugins/grafana-kairosdb-datasource/partials/query.editor.html';
 
     KairosDBQueryCtrl.prototype.targetBlur = function() {
       this.target.errors = validateTarget(this.target);


### PR DESCRIPTION
When grafana registers the plugin route, it will do so with:
Plugins: Adding route /public/plugins/grafana-kairosdb-datasource -> /var/lib/grafana/plugins/datasource-plugin-kairosdb

However, the string value for templateURL sends requests to a route of /public/plugins/kairosdb. This pull fixes the templateURL to match the actual route.