### PR TITLE
Fixed dependency injection issue that broke dateMath

### DIFF
--- a/datasource.js
+++ b/datasource.js
@@ -6,7 +6,7 @@ define([
   'app/core/utils/kbn',
   './query_ctrl'
 ],
-function (angular, _, dateMath, kbn) {
+function (angular, _, sdk, dateMath, kbn) {
   'use strict';
 
   var self;


### PR DESCRIPTION
It caused "dateMath.parse is not a function" errors on our Grafana 3.0 dashboards after upgrade.