### PR TITLE
fix trim aggregator

### DIFF
--- a/query_ctrl.js
+++ b/query_ctrl.js
@@ -279,6 +279,9 @@ function (angular, _, sdk) {
         if (this.target.hasPercentile) {
           aggregator.percentile = this.target.horAggregator.percentile;
         }
+        if (this.target.hasTrim) {
+          aggregator.trim = this.target.horAggregator.trim;
+        }
         this.target.horizontalAggregators.push(aggregator);
         this.targetBlur();
       }


### PR DESCRIPTION
The trim aggregator does not work because the data field "trim" is missing in the aggregator. This is due to KairosDBQueryCtrl.addHorizontalAggregator losing the "trim" field somehow.

This fixes it.