### PR TITLE
Add support for simple moving average (sma) aggregator

### DIFF
--- a/datasource.js
+++ b/datasource.js
@@ -417,6 +417,10 @@ function (angular, _, sdk, dateMath, kbn) {
           returnedAggregator.trim = chosenAggregator.trim;
         }
 
+        if (chosenAggregator.size) {
+          returnedAggregator.size = chosenAggregator.size;
+        }
+
         query.aggregators.push(returnedAggregator);
       });
     }

--- a/partials/query.editor.html
+++ b/partials/query.editor.html
@@ -223,7 +223,7 @@
         <select class="input-medium gf-form-input"
           ng-change="ctrl.changeHorAggregationInput()"
           ng-model="ctrl.target.currentHorizontalAggregatorName"
-          ng-options="f for f in ['avg','dev','max','min','rate','sampler','count','sum','least_squares','percentile','scale','div', 'first', 'gaps', 'last', 'diff', 'trim']"></select>
+          ng-options="f for f in ['avg','dev','max','min','rate','sampler','count','sum','least_squares','percentile','scale','div', 'first', 'gaps', 'last', 'diff', 'trim', 'sma']"></select>
       </span>
 
       <!-- Different parameters -->
@@ -298,6 +298,20 @@
           ng-model="ctrl.target.horAggregator.trim"
           ng-init="ctrl.target.horAggregator.trim='both'"
           ng-options="f for f in ['both','first','last']"></select>
+      </span>
+
+      <span ng-show="ctrl.target.hasSize">
+        <input type="text"
+        class="input-mini gf-form-input"
+        ng-model="ctrl.target.horAggregator.size"
+        ng-init="ctrl.target.horAggregator.size='10'"
+        spellcheck='false'
+        ng-change="ctrl.validateHorizontalAggregator()" >
+        <a bs-tooltip="ctrl.target.errors.horAggregator.size"
+          style="color: rgb(229, 189, 28)"
+          ng-show="ctrl.target.errors.horAggregator.size">
+          <i class="fa fa-warning"></i>
+        </a>
       </span>
 
       <label class="gf-form-label width-2.5" ng-show="ctrl.target.addHorizontalAggregatorMode">

--- a/query_ctrl.js
+++ b/query_ctrl.js
@@ -294,6 +294,9 @@ function (angular, _, sdk) {
         if (this.target.hasTrim) {
           aggregator.trim = this.target.horAggregator.trim;
         }
+        if (this.target.hasSize) {
+          aggregator.size = this.target.horAggregator.size;
+        }
         this.target.horizontalAggregators.push(aggregator);
         this.targetBlur();
       }
@@ -305,6 +308,7 @@ function (angular, _, sdk) {
       this.target.hasNothing = false;
       this.target.hasPercentile = false;
       this.target.hasTrim = false;
+      this.target.hasSize = false;
     };
 
     KairosDBQueryCtrl.prototype.removeHorizontalAggregator = function (index) {
@@ -326,6 +330,7 @@ function (angular, _, sdk) {
       this.target.hasNothing = _.includes(['diff'], this.target.currentHorizontalAggregatorName);
       this.target.hasPercentile = 'percentile' === this.target.currentHorizontalAggregatorName;
       this.target.hasTrim = _.includes(['trim'], this.target.currentHorizontalAggregatorName);
+      this.target.hasSize = _.includes(['sma'], this.target.currentHorizontalAggregatorName);
       this.validateHorizontalAggregator();
     };
 
@@ -369,6 +374,17 @@ function (angular, _, sdk) {
           this.target.horAggregator.trim !== 'first' &&
           this.target.horAggregator.trim !== 'last')) {
           errors.trim = 'Trim must be of value both, first, or last';
+          this.target.isAggregatorValid = false;
+        }
+      }
+
+      if (this.target.hasSize) {
+        if (!this.target.horAggregator.size) {
+          errors.size = 'You must supply a numeric value for this aggregator';
+          this.target.isAggregatorValid = false;
+        }
+        else if (parseInt(this.target.horAggregator.size) <= 0) {
+          errors.size = 'Value should be larger than 0';
           this.target.isAggregatorValid = false;
         }
       }


### PR DESCRIPTION
Adds the support for KairosDB moving average aggregator (SmaAggregator). 

![interface elements](http://i.imgur.com/WgEFAWp.png)

Without SMA:
![without](http://i.imgur.com/aJcLN1M.png)

With SMA:
![without](http://i.imgur.com/scwxyHy.png)

Fixes #56 
