### PR TITLE
Tag key/value validation errors not shown on hover of warning icon

### DIFF
--- a/partials/query.editor.html
+++ b/partials/query.editor.html
@@ -58,7 +58,7 @@
         data-min-length=0 data-items=100
         ng-model="ctrl.target.currentTagValue"
         placeholder="value">
-        <a bs-tooltip="target.errors.tags"
+        <a bs-tooltip="ctrl.target.errors.tags"
           style="color: rgb(229, 189, 28)"
           ng-show="ctrl.target.errors.tags">
           <i class="fa fa-warning"></i>


### PR DESCRIPTION
Typo bug: tag key/value validation errors not shown on hover of warning icon