### PR TITLE
Add README.md to dist as expected from Grafana plugin repo

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,9 +25,9 @@ module.exports = function (grunt) {
                 src: ["**/*", "!**/*.js", "!**/*.scss", "!node_modules/**/*"],
                 dest: "dist"
             },
-            pluginDef: {
+            metadata: {
                 expand: true,
-                src: ["plugin.json"],
+                src: ["plugin.json", "README.md"],
                 dest: "dist"
             }
         },

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,27 @@
+Starting in Grafana 3.x the KairosDB data source is no longer included out of the box.
+
+But it is easy to install this plugin!
+
+## Installation
+Either clone this repo into your grafana plugins directory (default /var/lib/grafana/plugins if your installing grafana with package). Then run grunt to compile typescript.
+Restart grafana-server and the plugin should be automatically detected and used.
+
+```
+git clone https://github.com/grafana/kairosdb-datasource
+npm install
+grunt
+sudo service grafana-server restart
+```
+
+## Clone into a directory of your choice
+
+Then edit your grafana.ini config file (Default location is at /etc/grafana/grafana.ini) and add this:
+
+```ini
+[plugin.kairosdb]
+path = /home/your/clone/dir/datasource-plugin-kairosdb
+```
+
+Note that if you clone it into the grafana plugins directory you do not need to add the above config option. That is only
+if you want to place the plugin in a directory outside the standard plugins directory. Be aware that grafana-server
+needs read access to the directory.


### PR DESCRIPTION
CI on grafana/grafana-plugin-repository#278 is failing because it expects a `README.md` in our dist folder.

This PR adds just that to the grunt task. Here I group it with the existing `pluginDef`, but I could also separate them if desired.

This is a part of resolving #68 

Is a version bump necessary?